### PR TITLE
Fix kstorage removal bookkeeping

### DIFF
--- a/kernel/patch/common/kstorage.c
+++ b/kernel/patch/common/kstorage.c
@@ -226,7 +226,7 @@ int remove_kstorage(int gid, long did)
             list_del_rcu(&pos->list);
             spin_unlock(lock);
 
-            group_sizes[did]--;
+            group_sizes[gid]--;
 
             bool async = true;
             if (async) {
@@ -241,7 +241,7 @@ int remove_kstorage(int gid, long did)
 
     spin_unlock(lock);
 
-    return 0;
+    return rc;
 }
 KP_EXPORT_SYMBOL(remove_kstorage);
 


### PR DESCRIPTION
## Summary
- ensure kstorage removal decrements the proper group counter
- propagate error code when removing a nonexistent entry

## Testing
- `make -C kernel` *(fails: TARGET_COMPILE not set)*

------
https://chatgpt.com/codex/tasks/task_e_68973610b2ac8332874ee61d8824feae